### PR TITLE
docs(morphology-v2): update error response schemas in api docs

### DIFF
--- a/apps/docs/content/docs/services/morphology-v2/morphology-v2.yaml
+++ b/apps/docs/content/docs/services/morphology-v2/morphology-v2.yaml
@@ -96,7 +96,43 @@ paths:
                     example: "Bad Request"
                   detail:
                     type: string
-                    example: "Invalid request parameters."
+                    example: "Invalid request."
+                  type:
+                    type: string
+                    example: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+                  errors:
+                    type: array
+                    example: []
+              example:
+                status: 400
+                title: "Bad Request"
+                detail: "Invalid request."
+                type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+                errors: []
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Unauthorized"
+              example:
+                message: "Unauthorized"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Message:
+                    type: string
+                    example: "User is not authorized to access this resource with an explicit deny"
+              example:
+                Message: "User is not authorized to access this resource with an explicit deny"
         '500':
           description: Internal Server Error
           content:
@@ -107,6 +143,42 @@ paths:
                   message:
                     type: string
                     example: "Endpoint request timed out"
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 502
+                  title:
+                    type: string
+                    example: "Bad Gateway"
+                  detail:
+                    type: string
+                    example: "Server got an invalid response."
+                  type:
+                    type: string
+                    example: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+              example:
+                status: 502
+                title: "Bad Gateway"
+                detail: "Server got an invalid response."
+                type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+        '504':
+          description: Gateway Timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Endpoint request timed out"
+              example:
+                message: "Endpoint request timed out"
       security:
         - apiKey: []
 
@@ -155,7 +227,43 @@ paths:
                     example: "Bad Request"
                   detail:
                     type: string
-                    example: "Invalid request parameters."
+                    example: "Invalid request."
+                  type:
+                    type: string
+                    example: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+                  errors:
+                    type: array
+                    example: []
+              example:
+                status: 400
+                title: "Bad Request"
+                detail: "Invalid request."
+                type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+                errors: []
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Unauthorized"
+              example:
+                message: "Unauthorized"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Message:
+                    type: string
+                    example: "User is not authorized to access this resource with an explicit deny"
+              example:
+                Message: "User is not authorized to access this resource with an explicit deny"
         '500':
           description: Internal Server Error
           content:
@@ -166,6 +274,42 @@ paths:
                   message:
                     type: string
                     example: "Endpoint request timed out"
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 502
+                  title:
+                    type: string
+                    example: "Bad Gateway"
+                  detail:
+                    type: string
+                    example: "Server got an invalid response."
+                  type:
+                    type: string
+                    example: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+              example:
+                status: 502
+                title: "Bad Gateway"
+                detail: "Server got an invalid response."
+                type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+        '504':
+          description: Gateway Timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Endpoint request timed out"
+              example:
+                message: "Endpoint request timed out"
       security:
         - apiKey: []
 
@@ -244,7 +388,43 @@ paths:
                     example: "Bad Request"
                   detail:
                     type: string
-                    example: "Invalid request parameters."
+                    example: "Invalid request."
+                  type:
+                    type: string
+                    example: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+                  errors:
+                    type: array
+                    example: []
+              example:
+                status: 400
+                title: "Bad Request"
+                detail: "Invalid request."
+                type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400"
+                errors: []
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Unauthorized"
+              example:
+                message: "Unauthorized"
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Message:
+                    type: string
+                    example: "User is not authorized to access this resource with an explicit deny"
+              example:
+                Message: "User is not authorized to access this resource with an explicit deny"
         '500':
           description: Internal Server Error
           content:
@@ -255,6 +435,42 @@ paths:
                   message:
                     type: string
                     example: "Endpoint request timed out"
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: integer
+                    example: 502
+                  title:
+                    type: string
+                    example: "Bad Gateway"
+                  detail:
+                    type: string
+                    example: "Server got an invalid response."
+                  type:
+                    type: string
+                    example: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+              example:
+                status: 502
+                title: "Bad Gateway"
+                detail: "Server got an invalid response."
+                type: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/502"
+        '504':
+          description: Gateway Timeout
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Endpoint request timed out"
+              example:
+                message: "Endpoint request timed out"
       security:
         - apiKey: []
 


### PR DESCRIPTION
Add detailed error response schemas for 400, 401, 403, 502, and 504 status codes Include type references and example arrays for better API documentation